### PR TITLE
FIX: assignments in Python3 grammar

### DIFF
--- a/python3-cs/Python3Parser.g4
+++ b/python3-cs/Python3Parser.g4
@@ -74,9 +74,9 @@ small_stmt: (expr_stmt | del_stmt | pass_stmt | flow_stmt |
 
 expr_stmt: testlist_star_expr | annassign | augassign | assign;
 
-assign: testlist_star_expr (ASSIGN (yield_expr|testlist_star_expr))*;
+assign: testlist_star_expr (ASSIGN testlist_star_expr)* (ASSIGN yield_expr)?;
 
-annassign: testlist_star_expr COLON test (ASSIGN test)? (yield_expr|testlist);
+annassign: testlist_star_expr COLON test (ASSIGN testlist)?;
 
 testlist_star_expr: (test|star_expr) (COMMA (test|star_expr))* (COMMA)?;
 

--- a/python3-cs/Python3Parser.g4
+++ b/python3-cs/Python3Parser.g4
@@ -49,15 +49,13 @@ if_stmt: IF test COLON suite (elif_clause)* (else_clause)?;
 elif_clause: ELIF test COLON suite;
 while_stmt: WHILE test COLON suite (else_clause)?;
 for_stmt: FOR exprlist IN testlist COLON suite (else_clause)?;
-try_stmt: (TRY COLON suite
-           ((except_clause+ else_clause? finaly_clause?)
-            |finaly_clause));
+try_stmt: TRY COLON suite ((except_clause+ else_clause? finally_clause?) | finally_clause);
 with_stmt: WITH with_item (COMMA with_item)*  COLON suite;
 with_item: test (AS expr)?;
 // NB compile.c makes sure that the default except clause is last
 except_clause: EXCEPT (test (AS NAME)?)? COLON suite;
 else_clause: ELSE COLON suite;
-finaly_clause: FINALLY COLON suite;
+finally_clause: FINALLY COLON suite;
 suite: simple_stmt | NEWLINE INDENT stmt+ DEDENT;
 
 simple_stmt: small_stmt (SEMI_COLON small_stmt)* (SEMI_COLON)? (NEWLINE | EOF);

--- a/python3-cs/cases/async_stmt.py
+++ b/python3-cs/cases/async_stmt.py
@@ -1,0 +1,11 @@
+# async_stmt: ASYNC (with_stmt | for_stmt);
+
+# async_stmt must be inside async function
+async def f():
+    # ASYNC with_stmt
+    async with open("async_stmt.py") as f:
+        pass
+
+    # ASYNC for_stmt
+    async for _ in range(5):
+        pass

--- a/python3-cs/cases/expr_stmt.py
+++ b/python3-cs/cases/expr_stmt.py
@@ -1,0 +1,38 @@
+# expr_stmt: testlist_star_expr | annassign | augassign | assign;
+#
+# assign: testlist_star_expr (ASSIGN testlist_star_expr)* (ASSIGN yield_expr)?;
+#
+# annassign: testlist_star_expr COLON test (ASSIGN testlist)?;
+#
+# augassign: testlist_star_expr op=('+=' | '-=' | '*=' | '@=' | '/=' | '%=' | '&=' | '|=' | '^=' |
+#               '<<=' | '>>=' | '**=' | '//=') (yield_expr|testlist);
+
+# Yield tests (should not be used outside the function)
+def f():
+    # assign: testlist_star_expr ASSIGN yield_expr
+    x = yield
+
+    # assign: testlist_star_expr ASSIGN testlist_star_expr ASSIGN yield_expr
+    x = y = yield
+
+    # augassign: testlist_star_expr '+=' yield_expr
+    x += yield
+
+# testlist_star_expr
+f()
+
+# assign: testlist_star_expr ASSIGN testlist_star_expr
+z = 5
+
+# assign: testlist_star_expr ASSIGN testlist_star_expr ASSIGN testlist_star_expr
+x = y = z
+
+# annassign: testlist_star_expr COLON test
+x: int
+
+# annassign: testlist_star_expr COLON test ASSIGN testlist
+x: int = 8
+
+# augassign: testlist_star_expr '-=' testlist
+x -= 9
+

--- a/python3-cs/cases/for_stmt.py
+++ b/python3-cs/cases/for_stmt.py
@@ -1,0 +1,11 @@
+# for_stmt: FOR exprlist IN testlist COLON suite (else_clause)?;
+
+# FOR exprlist IN testlist COLON suite
+for x in range(1):
+    pass
+
+# FOR exprlist IN testlist COLON suite (else_clause)?
+for x in range(1):
+    x
+else:
+    pass

--- a/python3-cs/cases/if_stmt.py
+++ b/python3-cs/cases/if_stmt.py
@@ -1,0 +1,25 @@
+# if_stmt: IF test COLON suite (elif_clause)* (else_clause)?
+
+# IF test COLON suite
+if x == 5:
+    pass
+
+# IF test COLON suite elif_clause
+if x == 4:
+    pass
+elif x == 3:
+    pass
+
+# IF test COLON suite else_clause
+if x == 7:
+    pass
+else:
+    pass
+
+# IF test COLON suite elif_clause elif_clause else_clause
+if x == 4:
+    pass
+elif x == 3:
+    pass
+else:
+    pass

--- a/python3-cs/cases/simple_stmt.py
+++ b/python3-cs/cases/simple_stmt.py
@@ -1,0 +1,13 @@
+# simple_stmt: small_stmt (SEMI_COLON small_stmt)* (SEMI_COLON)? (NEWLINE | EOF);
+
+# small_stmt NEWLINE
+x = 5
+
+# small_stmt SEMI_COLON small_stmt NEWLINE
+x = 5 ; y = 7
+
+# small_stmt SEMI_COLON NEWLINE
+x = 5 ;
+
+# small_stmt SEMI_COLON small_stmt SEMI_COLON small_stmt SEMI_COLON small_stmt SEMI_COLON EOF
+x = 5 ; y = 7 ; z = 9 ;

--- a/python3-cs/cases/try_stmt.py
+++ b/python3-cs/cases/try_stmt.py
@@ -1,0 +1,31 @@
+# try_stmt: TRY COLON suite ((except_clause+ else_clause? finaly_clause?) | finaly_clause);
+
+# TRY COLON suite except_clause
+try:
+    pass
+except:
+    pass
+
+# TRY COLON suite except_clause except_clause else_clause
+try:
+    pass
+except Exception as ex:
+    pass
+except:
+    pass
+else:
+    pass
+
+# TRY COLON suite except_clause finaly_clause
+try:
+    pass
+except Exception:
+    pass
+finally:
+    pass
+
+# TRY COLON suite finaly_clause
+try:
+    pass
+finally:
+    pass

--- a/python3-cs/cases/while_stmt.py
+++ b/python3-cs/cases/while_stmt.py
@@ -1,0 +1,11 @@
+# while_stmt: WHILE test COLON suite (else_clause)?
+
+# WHILE test COLON suite
+while x == 3:
+    x += 1
+
+# WHILE test COLON suite else_clause
+while x == 3:
+    x += 1
+else:
+    pass

--- a/python3-cs/cases/with_stmt.py
+++ b/python3-cs/cases/with_stmt.py
@@ -1,0 +1,9 @@
+# with_stmt: WITH with_item (COMMA with_item)*  COLON suite;
+
+# WITH with_item COLON suite
+with open("with_stmt.py"):
+    pass
+
+# WITH with_item COMMA with_item COLON suite
+with open("with_stmt.py") as a, open("with_stmt.py") as b:
+    pass


### PR DESCRIPTION
Previously, it was possible to successfully pass following statements:
```python3
x = yield = 5
x: int = 6 7, 8, 9
x: int = 6 yield
```
But this one -- nope
```python3
x: Tuple[int] = 5, 6
```

Also, some tests (PT.PM PR soon)