### PR TITLE
FIX: trailing comma in typedargslist

### DIFF
--- a/python/PythonParser.g4
+++ b/python/PythonParser.g4
@@ -47,9 +47,10 @@ decorator
     ;
 
 //python 3 paramters
+// parameters list may have a trailing comma
 typedargslist
-    : (def_parameters COMMA)? (args (COMMA def_parameters)? (COMMA kwargs)? | kwargs)
-    | def_parameters
+    : (def_parameters COMMA)? (args (COMMA def_parameters)? (COMMA kwargs)? | kwargs) COMMA?
+    | def_parameters COMMA?
     ;
 
 args

--- a/python/samples/typedargslist.py
+++ b/python/samples/typedargslist.py
@@ -1,0 +1,17 @@
+# typedargslist
+#     : (def_parameters COMMA)? (args (COMMA def_parameters)? (COMMA kwargs)? | kwargs)
+#     | def_parameters
+#     ;
+
+# def_parameters COMMA
+def single(x,): pass
+
+# def_parameters COMMA kwargs
+def f1(x, y, **z): pass
+
+# def_parameters COMMA args COMMA def_parameters COMMA kwargs COMMA
+def f1(x, y, *z, a, b, **c,): pass
+
+# def_parameters COMMA args
+def f1(x, y, *z): pass
+


### PR DESCRIPTION
In Python 3 (maybe also 2, I don't know) we can define a function like this
```python
def f(a, b, c,):
    pass
```
So the parser should accept this one, too.
Tests in `sample` folder included